### PR TITLE
Expose card scanning components for SwiftUI customization

### DIFF
--- a/Example/UI Examples/README.md
+++ b/Example/UI Examples/README.md
@@ -4,5 +4,7 @@ This example app lets you try out the pre-built UI components we provide.
 
 You can run it without any initial setup and it's a great place to start to use our UI components individually.
 
+The "Card Scan (SwiftUI)" sample shows how to host `SimpleScanViewController` inside a SwiftUI flow and customize its look and feel while receiving live scan updates.
+
 1. Open `stripe-ios/Stripe.xcworkspace` (not `stripe-ios/Stripe.xcodeproj`) with Xcode
 2. Build and run the "UI Examples" scheme

--- a/Example/UI Examples/UI Examples.xcodeproj/project.pbxproj
+++ b/Example/UI Examples/UI Examples.xcodeproj/project.pbxproj
@@ -31,6 +31,9 @@
 		EB04DF08EF3D94B6AAA5B441 /* StripeApplePay.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = FEC7ADA06B237EFA9BA61939 /* StripeApplePay.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F9A86FC25BDB54F3D64FE458 /* CardFormViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0EE0C28786C46F7AD5678C4 /* CardFormViewController.swift */; };
 		FCB92C416FBB9287BAE1FCDF /* SwiftUICardFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C2F92F71B779415739E02D5 /* SwiftUICardFormView.swift */; };
+		23BA9B734F93408F8DB4B4B2 /* SwiftUICardScanView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2FCFEDE1E634F02BA5CF864 /* SwiftUICardScanView.swift */; };
+		5F572FB702AE4646931BFAE9 /* StripeCardScan.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AE8C5ACBCB644E295CB37ED /* StripeCardScan.framework */; };
+		CA53331B554B4CD6908A2534 /* StripeCardScan.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9AE8C5ACBCB644E295CB37ED /* StripeCardScan.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -47,6 +50,7 @@
 				0ED675CAC09C7DD24824F4C2 /* StripePaymentsUI.framework in Embed Frameworks */,
 				546290D05670988D27885299 /* StripeUICore.framework in Embed Frameworks */,
 				0CDE3A1203737BFD5C5629D9 /* Stripe.framework in Embed Frameworks */,
+				CA53331B554B4CD6908A2534 /* StripeCardScan.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -66,6 +70,7 @@
 		460B319B13534E7889F7DADE /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		592779C24B55133469B657A2 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		5C2F92F71B779415739E02D5 /* SwiftUICardFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUICardFormView.swift; sourceTree = "<group>"; };
+		A2FCFEDE1E634F02BA5CF864 /* SwiftUICardScanView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUICardScanView.swift; sourceTree = "<group>"; };
 		69382A94399A814B97E6BF13 /* BrowseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowseViewController.swift; sourceTree = "<group>"; };
 		6E1B9A78F0BE9BE3D542CB7D /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		74B92067761E45B0D87100A7 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -84,6 +89,7 @@
 		D7D4CC026D81D7E26EDA474B /* StripePayments.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripePayments.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E8BFFBA74634A24020A4E389 /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/Localizable.strings; sourceTree = "<group>"; };
 		F16D8E3EDF1E3CCBF5FE6F36 /* StripeCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9AE8C5ACBCB644E295CB37ED /* StripeCardScan.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeCardScan.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F351572061CC8F516217BD0F /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
 		F3F01AF08C8165512BFF2CEC /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
 		FEC7ADA06B237EFA9BA61939 /* StripeApplePay.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeApplePay.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -100,6 +106,7 @@
 				3B902170875FA481C136290D /* StripePayments.framework in Frameworks */,
 				BC632EA0072370EB316B5088 /* StripePaymentsUI.framework in Frameworks */,
 				97628266E1DFA00F28045C7C /* StripeUICore.framework in Frameworks */,
+				5F572FB702AE4646931BFAE9 /* StripeCardScan.framework in Frameworks */,
 				3BCB2193E00E9B8766E93AC9 /* Stripe.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -143,6 +150,7 @@
 				D0EE0C28786C46F7AD5678C4 /* CardFormViewController.swift */,
 				931AF426917A2801C4205F00 /* MockCustomerContext.swift */,
 				5C2F92F71B779415739E02D5 /* SwiftUICardFormView.swift */,
+				A2FCFEDE1E634F02BA5CF864 /* SwiftUICardScanView.swift */,
 				2CEA2C4F5B6850B738224532 /* ThemeViewController.swift */,
 			);
 			path = Source;
@@ -186,6 +194,7 @@
 				D7D4CC026D81D7E26EDA474B /* StripePayments.framework */,
 				28B1F86587A2774EF158BDE9 /* StripePaymentsUI.framework */,
 				A7973A50BA0AE6BE3911FCE8 /* StripeUICore.framework */,
+				9AE8C5ACBCB644E295CB37ED /* StripeCardScan.framework */,
 				33045CD268B7E20221AEF345 /* UIExamples.app */,
 			);
 			name = Products;
@@ -289,6 +298,7 @@
 				F9A86FC25BDB54F3D64FE458 /* CardFormViewController.swift in Sources */,
 				566876172C33FCC7ACB66754 /* MockCustomerContext.swift in Sources */,
 				FCB92C416FBB9287BAE1FCDF /* SwiftUICardFormView.swift in Sources */,
+				23BA9B734F93408F8DB4B4B2 /* SwiftUICardScanView.swift in Sources */,
 				B7B3DEBC7275C023C0CAC30D /* ThemeViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/UI Examples/UI Examples/Source/BrowseViewController.swift
+++ b/Example/UI Examples/UI Examples/Source/BrowseViewController.swift
@@ -17,7 +17,7 @@ class BrowseViewController: UITableViewController
 {
 
     enum Demo: Int {
-        static var count: Int = 8
+        static var count: Int = 9
 
         case STPPaymentCardTextField
         case STPPaymentCardTextFieldWithCBC
@@ -25,6 +25,7 @@ class BrowseViewController: UITableViewController
         case STPCardFormViewController
         case STPCardFormViewControllerCBC
         case SwiftUICardFormViewController
+        case SwiftUICardScanViewController
 
         var title: String {
             switch self {
@@ -34,6 +35,7 @@ class BrowseViewController: UITableViewController
             case .STPCardFormViewController: return "Card Form"
             case .STPCardFormViewControllerCBC: return "Card Form (CBC)"
             case .SwiftUICardFormViewController: return "Card Form (SwiftUI)"
+            case .SwiftUICardScanViewController: return "Card Scan (SwiftUI)"
             }
         }
 
@@ -45,6 +47,7 @@ class BrowseViewController: UITableViewController
             case .STPCardFormViewController: return "STPCardFormViewController"
             case .STPCardFormViewControllerCBC: return "STPCardFormViewController (CBC)"
             case .SwiftUICardFormViewController: return "STPCardFormView.Representable"
+            case .SwiftUICardScanViewController: return "SimpleScanViewController"
             }
         }
     }
@@ -113,6 +116,10 @@ class BrowseViewController: UITableViewController
             present(navigationController, animated: true, completion: nil)
         case .SwiftUICardFormViewController:
             let controller = UIHostingController(rootView: SwiftUICardFormView())
+            present(controller, animated: true, completion: nil)
+        case .SwiftUICardScanViewController:
+            let controller = UIHostingController(rootView: SwiftUICardScanView())
+            controller.modalPresentationStyle = .fullScreen
             present(controller, animated: true, completion: nil)
         }
     }

--- a/Example/UI Examples/UI Examples/Source/SwiftUICardScanView.swift
+++ b/Example/UI Examples/UI Examples/Source/SwiftUICardScanView.swift
@@ -1,0 +1,218 @@
+//
+//  SwiftUICardScanView.swift
+//  UI Examples
+//
+//  Created by Stripe on 2024.
+//  Copyright © 2024 Stripe. All rights reserved.
+//
+
+import StripeCardScan
+import SwiftUI
+import UIKit
+
+struct SwiftUICardScanView: View {
+
+    @State private var isPresentingScanner = false
+    @State private var scannedCard: ScannedCard?
+    @State private var statusMessage: String?
+    @State private var statusTint: Color = .secondary
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Spacer(minLength: 32)
+
+            VStack(spacing: 8) {
+                Text("SwiftUI Card Scan")
+                    .font(.largeTitle)
+                    .bold()
+
+                Text("Present the native camera experience inside a SwiftUI flow and react to scan updates in real time.")
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(.secondary)
+            }
+            .padding(.horizontal)
+
+            if let scannedCard {
+                CardScanResultView(card: scannedCard)
+                    .transition(.opacity)
+            } else {
+                Text("No card scanned yet")
+                    .font(.headline)
+                    .foregroundColor(.secondary)
+            }
+
+            Button {
+                statusMessage = nil
+                statusTint = .secondary
+                isPresentingScanner = true
+            } label: {
+                HStack(spacing: 8) {
+                    Image(systemName: "camera.fill")
+                    Text("Scan card")
+                        .fontWeight(.semibold)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+                .padding(.horizontal, 16)
+                .background(Color.accentColor)
+                .foregroundColor(.white)
+                .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+            }
+            .padding(.horizontal)
+
+            if let statusMessage {
+                Text(statusMessage)
+                    .font(.footnote)
+                    .foregroundColor(statusTint)
+            }
+
+            Spacer()
+        }
+        .padding(.vertical)
+        .background(Color(uiColor: .systemBackground))
+        .sheet(isPresented: $isPresentingScanner) {
+            CardScannerRepresentable(isPresented: $isPresentingScanner) { result in
+                switch result {
+                case .completed(let card):
+                    withAnimation {
+                        scannedCard = card
+                        statusMessage = "Scanned card saved"
+                        statusTint = .green
+                    }
+                case .canceled:
+                    statusMessage = "Scan canceled"
+                    statusTint = .secondary
+                case .failed(let error):
+                    statusMessage = error.localizedDescription
+                    statusTint = .red
+                }
+            }
+            .ignoresSafeArea()
+        }
+    }
+}
+
+private struct CardScanResultView: View {
+    let card: ScannedCard
+
+    private var formattedPan: String {
+        let trimmed = card.pan.replacingOccurrences(of: " ", with: "")
+        guard trimmed.count > 4 else { return card.pan }
+        let lastFour = trimmed.suffix(4)
+        return "•••• " + lastFour
+    }
+
+    private var formattedExpiry: String {
+        guard let month = card.expiryMonth, let year = card.expiryYear else {
+            return ""
+        }
+        return "Expires \(month)/\(year)"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Scanned card")
+                .font(.headline)
+            Text(formattedPan)
+                .font(.title2)
+                .bold()
+            if !formattedExpiry.isEmpty {
+                Text(formattedExpiry)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+            if let name = card.name, !name.isEmpty {
+                Text(name)
+                    .font(.subheadline)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color(uiColor: .secondarySystemBackground))
+        )
+        .padding(.horizontal)
+    }
+}
+
+private struct CardScannerRepresentable: UIViewControllerRepresentable {
+    @Binding var isPresented: Bool
+    let onCompletion: (CardScanSheetResult) -> Void
+
+    func makeUIViewController(context: Context) -> DemoScanViewController {
+        let controller = DemoScanViewController()
+        controller.delegate = context.coordinator
+        controller.scanPerformancePriority = .accurate
+        controller.maxErrorCorrectionDuration = 8
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: DemoScanViewController, context: Context) {
+        context.coordinator.parent = self
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    final class Coordinator: NSObject, SimpleScanDelegate {
+        var parent: CardScannerRepresentable
+
+        init(parent: CardScannerRepresentable) {
+            self.parent = parent
+        }
+
+        func userDidCancelSimple(_ scanViewController: SimpleScanViewController) {
+            parent.isPresented = false
+            parent.onCompletion(.canceled)
+        }
+
+        func userDidScanCardSimple(
+            _ scanViewController: SimpleScanViewController,
+            creditCard: CreditCard
+        ) {
+            parent.isPresented = false
+            parent.onCompletion(.completed(card: ScannedCard(scannedCard: creditCard)))
+        }
+    }
+}
+
+private final class DemoScanViewController: SimpleScanViewController {
+    override func setupUiComponents() {
+        super.setupUiComponents()
+        view.backgroundColor = UIColor.systemIndigo
+        descriptionText.text = "Align your card inside the frame"
+        descriptionText.textColor = .white
+        descriptionText.font = UIFont.preferredFont(forTextStyle: .title2)
+        descriptionText.numberOfLines = 2
+
+        closeButton.setTitle("Done", for: .normal)
+        torchButton.setTitle("Light", for: .normal)
+
+        if let torchImage = UIImage(systemName: "flashlight.on.fill") {
+            torchButton.setImage(torchImage, for: .normal)
+            torchButton.tintColor = .white
+            torchButton.imageEdgeInsets = UIEdgeInsets(top: 0, left: -4, bottom: 0, right: 4)
+        }
+
+        roiView.layer.borderColor = UIColor.systemGreen.cgColor
+        roiView.layer.borderWidth = 3
+        roiView.layer.cornerRadius = 18
+
+        enableCameraPermissionsButton.setTitleColor(.white, for: .normal)
+        enableCameraPermissionsText.textColor = .white
+        privacyLinkText.textColor = .white
+        privacyLinkText.linkTextAttributes = [
+            .foregroundColor: UIColor.systemTeal,
+            .underlineStyle: NSUnderlineStyle.single.rawValue,
+        ]
+        privacyLinkText.backgroundColor = .clear
+    }
+}
+
+struct SwiftUICardScanView_Previews: PreviewProvider {
+    static var previews: some View {
+        SwiftUICardScanView()
+    }
+}

--- a/StripeCardScan/StripeCardScan/Source/CardScan/CardUtils/Expiry.swift
+++ b/StripeCardScan/StripeCardScan/Source/CardScan/CardUtils/Expiry.swift
@@ -1,19 +1,25 @@
 import Foundation
 
-struct Expiry: Hashable {
-    let string: String
-    let month: UInt
-    let year: UInt
+public struct Expiry: Hashable {
+    public let string: String
+    public let month: UInt
+    public let year: UInt
 
-    static func == (lhs: Expiry, rhs: Expiry) -> Bool {
+    public init(string: String, month: UInt, year: UInt) {
+        self.string = string
+        self.month = month
+        self.year = year
+    }
+
+    public static func == (lhs: Expiry, rhs: Expiry) -> Bool {
         return lhs.string == rhs.string
     }
 
-    func hash(into hasher: inout Hasher) {
+    public func hash(into hasher: inout Hasher) {
         self.string.hash(into: &hasher)
     }
 
-    func display() -> String {
+    public func display() -> String {
         let twoDigitYear = self.year % 100
         return String(format: "%02d/%02d", self.month, twoDigitYear)
     }

--- a/StripeCardScan/StripeCardScan/Source/CardScan/CreditCardOcr/CreditCardOcrPrediction.swift
+++ b/StripeCardScan/StripeCardScan/Source/CardScan/CreditCardOcr/CreditCardOcrPrediction.swift
@@ -9,44 +9,56 @@
 import CoreGraphics
 import Foundation
 
-struct UxFrameConfidenceValues {
-    let hasOcr: Bool
-    let uxPan: Double
-    let uxNoPan: Double
-    let uxNoCard: Double
+public struct UxFrameConfidenceValues {
+    public let hasOcr: Bool
+    public let uxPan: Double
+    public let uxNoPan: Double
+    public let uxNoCard: Double
 
-    func toArray() -> [Double] {
+    public init(
+        hasOcr: Bool,
+        uxPan: Double,
+        uxNoPan: Double,
+        uxNoCard: Double
+    ) {
+        self.hasOcr = hasOcr
+        self.uxPan = uxPan
+        self.uxNoPan = uxNoPan
+        self.uxNoCard = uxNoCard
+    }
+
+    public func toArray() -> [Double] {
         return [hasOcr ? 1.0 : 0.0, uxPan, uxNoPan, uxNoCard]
     }
 }
 
-enum CenteredCardState {
+public enum CenteredCardState {
     case numberSide
     case nonNumberSide
     case noCard
 
-    func hasCard() -> Bool {
+    public func hasCard() -> Bool {
         return self == .numberSide || self == .nonNumberSide
     }
 }
 
-struct CreditCardOcrPrediction {
-    let image: CGImage
-    let ocrCroppingRectangle: CGRect
-    let number: String?
-    let expiryMonth: String?
-    let expiryYear: String?
-    let name: String?
-    let computationTime: Double
-    let numberBoxes: [CGRect]?
-    let expiryBoxes: [CGRect]?
-    let nameBoxes: [CGRect]?
+public struct CreditCardOcrPrediction {
+    public let image: CGImage
+    public let ocrCroppingRectangle: CGRect
+    public let number: String?
+    public let expiryMonth: String?
+    public let expiryYear: String?
+    public let name: String?
+    public let computationTime: Double
+    public let numberBoxes: [CGRect]?
+    public let expiryBoxes: [CGRect]?
+    public let nameBoxes: [CGRect]?
 
     // this is only used by Card Verify and the Liveness check and filled in by the UxModel
-    var centeredCardState: CenteredCardState?
-    var uxFrameConfidenceValues: UxFrameConfidenceValues?
+    public var centeredCardState: CenteredCardState?
+    public var uxFrameConfidenceValues: UxFrameConfidenceValues?
 
-    init(
+    public init(
         image: CGImage,
         ocrCroppingRectangle: CGRect,
         number: String?,
@@ -105,7 +117,7 @@ struct CreditCardOcrPrediction {
         )
     }
 
-    static func emptyPrediction(cgImage: CGImage) -> CreditCardOcrPrediction {
+    public static func emptyPrediction(cgImage: CGImage) -> CreditCardOcrPrediction {
         CreditCardOcrPrediction(
             image: cgImage,
             ocrCroppingRectangle: CGRect(),
@@ -120,19 +132,19 @@ struct CreditCardOcrPrediction {
         )
     }
 
-    var expiryForDisplay: String? {
+    public var expiryForDisplay: String? {
         guard let month = expiryMonth, let year = expiryYear else { return nil }
         return "\(month)/\(year)"
     }
 
-    var expiryAsUInt: (UInt, UInt)? {
+    public var expiryAsUInt: (UInt, UInt)? {
         guard let month = expiryMonth.flatMap({ UInt($0) }) else { return nil }
         guard let year = expiryYear.flatMap({ UInt($0) }) else { return nil }
 
         return (month, year)
     }
 
-    var numberBox: CGRect? {
+    public var numberBox: CGRect? {
         let xmin = numberBoxes?.map { $0.minX }.min() ?? 0.0
         let xmax = numberBoxes?.map { $0.maxX }.max() ?? 0.0
         let ymin = numberBoxes?.map { $0.minY }.min() ?? 0.0
@@ -140,11 +152,11 @@ struct CreditCardOcrPrediction {
         return CGRect(x: xmin, y: ymin, width: (xmax - xmin), height: (ymax - ymin))
     }
 
-    var expiryBox: CGRect? {
+    public var expiryBox: CGRect? {
         return expiryBoxes.flatMap { $0.first }
     }
 
-    var numberBoxesInFullImageFrame: [CGRect]? {
+    public var numberBoxesInFullImageFrame: [CGRect]? {
         guard let boxes = numberBoxes else { return nil }
         let cropOrigin = ocrCroppingRectangle.origin
         return boxes.map {
@@ -157,7 +169,7 @@ struct CreditCardOcrPrediction {
         }
     }
 
-    static func likelyExpiry(_ string: String) -> (String, String)? {
+    public static func likelyExpiry(_ string: String) -> (String, String)? {
         guard let regex = try? NSRegularExpression(pattern: "^.*(0[1-9]|1[0-2])[./]([1-2][0-9])$")
         else {
             return nil
@@ -179,7 +191,7 @@ struct CreditCardOcrPrediction {
         return (String(string[range1]), String(string[range2]))
     }
 
-    static func pan(_ text: String) -> String? {
+    public static func pan(_ text: String) -> String? {
         let digitsAndSpace = text.reduce(true) { $0 && (($1 >= "0" && $1 <= "9") || $1 == " ") }
         let number = text.compactMap { $0 >= "0" && $0 <= "9" ? $0 : nil }.map { String($0) }
             .joined()

--- a/StripeCardScan/StripeCardScan/Source/CardScan/CreditCardOcr/CreditCardOcrResult.swift
+++ b/StripeCardScan/StripeCardScan/Source/CardScan/CreditCardOcr/CreditCardOcrResult.swift
@@ -8,17 +8,17 @@
 
 import Foundation
 
-class CreditCardOcrResult: MachineLearningResult {
-    let mostRecentPrediction: CreditCardOcrPrediction
-    let number: String
-    let expiry: String?
-    let name: String?
-    let state: MainLoopState
+public class CreditCardOcrResult: MachineLearningResult {
+    public let mostRecentPrediction: CreditCardOcrPrediction
+    public let number: String
+    public let expiry: String?
+    public let name: String?
+    public let state: MainLoopState
 
     // this is only used by Card Verify and the Liveness check and filled in by the UxModel
-    var hasCenteredCard: CenteredCardState?
+    public var hasCenteredCard: CenteredCardState?
 
-    init(
+    public init(
         mostRecentPrediction: CreditCardOcrPrediction,
         number: String,
         expiry: String?,
@@ -35,14 +35,14 @@ class CreditCardOcrResult: MachineLearningResult {
         super.init(duration: duration, frames: frames)
     }
 
-    var expiryMonth: String? {
+    public var expiryMonth: String? {
         return expiry.flatMap { $0.split(separator: "/").first.map { String($0) } }
     }
-    var expiryYear: String? {
+    public var expiryYear: String? {
         return expiry.flatMap { $0.split(separator: "/").last.map { String($0) } }
     }
 
-    static func finishedWithNonNumberSideCard(
+    public static func finishedWithNonNumberSideCard(
         prediction: CreditCardOcrPrediction,
         duration: Double,
         frames: Int

--- a/StripeCardScan/StripeCardScan/Source/CardScan/CreditCardOcr/MachineLearningResult.swift
+++ b/StripeCardScan/StripeCardScan/Source/CardScan/CreditCardOcr/MachineLearningResult.swift
@@ -7,14 +7,14 @@
 
 import Foundation
 
-class MachineLearningResult {
-    let duration: Double
-    let frames: Int
-    var framePerSecond: Double {
+public class MachineLearningResult {
+    public let duration: Double
+    public let frames: Int
+    public var framePerSecond: Double {
         return Double(frames) / duration
     }
 
-    init(
+    public init(
         duration: Double,
         frames: Int
     ) {

--- a/StripeCardScan/StripeCardScan/Source/CardScan/CreditCardOcr/MainLoopStateMachine.swift
+++ b/StripeCardScan/StripeCardScan/Source/CardScan/CreditCardOcr/MainLoopStateMachine.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum MainLoopState: Equatable {
+public enum MainLoopState: Equatable {
     case initial
     case ocrOnly
     case cardOnly

--- a/StripeCardScan/StripeCardScan/Source/CardScan/CreditCardOcr/OcrMainLoop.swift
+++ b/StripeCardScan/StripeCardScan/Source/CardScan/CreditCardOcr/OcrMainLoop.swift
@@ -64,7 +64,7 @@
 
 import UIKit
 
-protocol OcrMainLoopDelegate: AnyObject {
+public protocol OcrMainLoopDelegate: AnyObject {
     func complete(creditCardOcrResult: CreditCardOcrResult)
     func prediction(
         prediction: CreditCardOcrPrediction,

--- a/StripeCardScan/StripeCardScan/Source/CardScan/UI/BlurView.swift
+++ b/StripeCardScan/StripeCardScan/Source/CardScan/UI/BlurView.swift
@@ -7,20 +7,20 @@
 
 import UIKit
 
-class BlurView: UIView {
-    required init?(
+public class BlurView: UIView {
+    required public init?(
         coder aDecoder: NSCoder
     ) {
         super.init(coder: aDecoder)
     }
 
-    override init(
+    public override init(
         frame: CGRect
     ) {
         super.init(frame: frame)
     }
 
-    func maskToRoi(roi: UIView) {
+    public func maskToRoi(roi: UIView) {
         let maskLayer = CAShapeLayer()
         let path = CGMutablePath()
         let roiCornerRadius = roi.layer.cornerRadius

--- a/StripeCardScan/StripeCardScan/Source/CardScan/UI/CardScanSheet.swift
+++ b/StripeCardScan/StripeCardScan/Source/CardScan/UI/CardScanSheet.swift
@@ -29,7 +29,7 @@ public class CardScanSheet {
     /// Presents a sheet for a customer to scan their card
     /// - Parameter presentingViewController: The view controller to present a card scan sheet
     /// - Parameter completion: Called with the result of the scan after the card scan sheet is dismissed
-            public func present(
+    public func present(
         from presentingViewController: UIViewController,
         completion: @escaping (CardScanSheetResult) -> Void,
         animated: Bool = true
@@ -71,11 +71,11 @@ public class CardScanSheet {
 }
 
 extension CardScanSheet: SimpleScanDelegate {
-    func userDidCancelSimple(_ scanViewController: SimpleScanViewController) {
+    public func userDidCancelSimple(_ scanViewController: SimpleScanViewController) {
         completion?(.canceled)
     }
 
-    func userDidScanCardSimple(
+    public func userDidScanCardSimple(
         _ scanViewController: SimpleScanViewController,
         creditCard: CreditCard
     ) {

--- a/StripeCardScan/StripeCardScan/Source/CardScan/UI/CornerView.swift
+++ b/StripeCardScan/StripeCardScan/Source/CardScan/UI/CornerView.swift
@@ -1,19 +1,19 @@
 import UIKit
 
-class CornerView: UIView {
-    required init?(
+public class CornerView: UIView {
+    required public init?(
         coder aDecoder: NSCoder
     ) {
         super.init(coder: aDecoder)
     }
 
-    override init(
+    public override init(
         frame: CGRect
     ) {
         super.init(frame: frame)
     }
 
-    func setFrameSize(roi: UIView) {
+    public func setFrameSize(roi: UIView) {
         let borderWidth = self.layer.borderWidth
         let width = roi.layer.bounds.width + 2 * borderWidth
         let height = roi.layer.bounds.height + 2 * borderWidth
@@ -26,7 +26,7 @@ class CornerView: UIView {
         self.layer.bounds = cornerViewBoundRect
     }
 
-    func drawCorners() {
+    public func drawCorners() {
         let maskShapeLayer = CAShapeLayer()
         let maskPath = CGMutablePath()
 

--- a/StripeCardScan/StripeCardScan/Source/CardScan/UI/PreviewView.swift
+++ b/StripeCardScan/StripeCardScan/Source/CardScan/UI/PreviewView.swift
@@ -44,8 +44,8 @@
 import AVFoundation
 import UIKit
 
-class PreviewView: UIView {
-    var videoPreviewLayer: AVCaptureVideoPreviewLayer {
+public class PreviewView: UIView {
+    public var videoPreviewLayer: AVCaptureVideoPreviewLayer {
         guard let layer = layer as? AVCaptureVideoPreviewLayer else {
             fatalError(
                 "Expected `AVCaptureVideoPreviewLayer` type for layer. Check PreviewView.layerClass implementation."
@@ -55,7 +55,7 @@ class PreviewView: UIView {
         return layer
     }
 
-    var session: AVCaptureSession? {
+    public var session: AVCaptureSession? {
         get {
             return videoPreviewLayer.session
         }
@@ -66,13 +66,13 @@ class PreviewView: UIView {
 
     // MARK: Initialization
 
-    override init(
+    public override init(
         frame: CGRect
     ) {
         super.init(frame: frame)
     }
 
-    required init?(
+    required public init?(
         coder aDecoder: NSCoder
     ) {
         super.init(coder: aDecoder)
@@ -80,11 +80,11 @@ class PreviewView: UIView {
 
     // MARK: UIView
 
-    override class var layerClass: AnyClass {
+    public override class var layerClass: AnyClass {
         return AVCaptureVideoPreviewLayer.self
     }
 
-    override func layoutSubviews() {
+    public override func layoutSubviews() {
         super.layoutSubviews()
     }
 }

--- a/StripeCardScan/StripeCardScan/Source/CardScan/UI/ScanBaseViewController.swift
+++ b/StripeCardScan/StripeCardScan/Source/CardScan/UI/ScanBaseViewController.swift
@@ -2,15 +2,15 @@ import AVKit
 import UIKit
 import Vision
 
-protocol TestingImageDataSource: AnyObject {
+public protocol TestingImageDataSource: AnyObject {
     func nextSquareAndFullImage() -> CGImage?
 }
 
-class ScanBaseViewController: UIViewController, AVCaptureVideoDataOutputSampleBufferDelegate,
+open class ScanBaseViewController: UIViewController, AVCaptureVideoDataOutputSampleBufferDelegate,
     AfterPermissions, OcrMainLoopDelegate
 {
 
-    lazy var testingImageDataSource: TestingImageDataSource? = {
+    public lazy var testingImageDataSource: TestingImageDataSource? = {
         var result: TestingImageDataSource?
         #if targetEnvironment(simulator)
             if ProcessInfo.processInfo.environment["UITesting"] != nil {
@@ -20,14 +20,14 @@ class ScanBaseViewController: UIViewController, AVCaptureVideoDataOutputSampleBu
         return result
     }()
 
-    var includeCardImage = false
-    var showDebugImageView = false
+    public var includeCardImage = false
+    public var showDebugImageView = false
 
-    var scanEventsDelegate: ScanEvents?
+    public var scanEventsDelegate: ScanEvents?
 
-    static var isAppearing = false
-    static var isPadAndFormsheet: Bool = false
-    static let machineLearningQueue = DispatchQueue(label: "CardScanMlQueue")
+    public static var isAppearing = false
+    public static var isPadAndFormsheet: Bool = false
+    public static let machineLearningQueue = DispatchQueue(label: "CardScanMlQueue")
     private let machineLearningSemaphore = DispatchSemaphore(value: 1)
 
     private weak var debugImageView: UIImageView?
@@ -39,7 +39,7 @@ class ScanBaseViewController: UIViewController, AVCaptureVideoDataOutputSampleBu
     private var previewViewFrame: CGRect?
 
     var videoFeed = VideoFeed()
-    var initialVideoOrientation: AVCaptureVideoOrientation {
+    open var initialVideoOrientation: AVCaptureVideoOrientation {
         if ScanBaseViewController.isPadAndFormsheet {
             return AVCaptureVideoOrientation(interfaceOrientation: UIWindow.interfaceOrientation)
                 ?? .portrait
@@ -48,10 +48,10 @@ class ScanBaseViewController: UIViewController, AVCaptureVideoDataOutputSampleBu
         }
     }
 
-    var scannedCardImage: UIImage?
+    public private(set) var scannedCardImage: UIImage?
     private var isNavigationBarHidden: Bool?
-    var hideNavigationBar: Bool?
-    var regionOfInterestCornerRadius = CGFloat(10.0)
+    public var hideNavigationBar: Bool?
+    public var regionOfInterestCornerRadius = CGFloat(10.0)
     private var calledOnScannedCard = false
 
     /// Flag to keep track of first time pan is observed
@@ -67,56 +67,57 @@ class ScanBaseViewController: UIViewController, AVCaptureVideoDataOutputSampleBu
     var predictedName: String?
 
     // Child classes should override these functions
-    func onScannedCard(
+    open func onScannedCard(
         number: String,
         expiryYear: String?,
         expiryMonth: String?,
         scannedImage: UIImage?
     ) {}
-    func showCardNumber(_ number: String, expiry: String?) {}
-    func showWrongCard(number: String?, expiry: String?, name: String?) {}
-    func showNoCard() {}
-    func onCameraPermissionDenied(showedPrompt: Bool) {}
-    func useCurrentFrameNumber(errorCorrectedNumber: String?, currentFrameNumber: String) -> Bool {
+    open func showCardNumber(_ number: String, expiry: String?) {}
+    open func showWrongCard(number: String?, expiry: String?, name: String?) {}
+    open func showNoCard() {}
+    open func onCameraPermissionDenied(showedPrompt: Bool) {}
+    open func useCurrentFrameNumber(errorCorrectedNumber: String?, currentFrameNumber: String) -> Bool {
         return true
     }
 
     // MARK: Inits
-    init() {
+    public init() {
         super.init(nibName: nil, bundle: nil)
     }
 
-    required init?(
+    @available(*, unavailable)
+    required public init?(
         coder: NSCoder
     ) {
         fatalError("init(coder:) has not been implemented")
     }
 
     // MARK: - Torch Logic
-    func toggleTorch() {
+    open func toggleTorch() {
         self.ocrMainLoop()?.scanStats.torchOn = !(self.ocrMainLoop()?.scanStats.torchOn ?? false)
         self.videoFeed.toggleTorch()
     }
 
-    func isTorchOn() -> Bool {
+    open func isTorchOn() -> Bool {
         return self.videoFeed.isTorchOn()
     }
 
-    func hasTorchAndIsAvailable() -> Bool {
+    open func hasTorchAndIsAvailable() -> Bool {
         return self.videoFeed.hasTorchAndIsAvailable()
     }
 
-    func setTorchLevel(level: Float) {
+    open func setTorchLevel(level: Float) {
         if 0.0...1.0 ~= level {
             self.videoFeed.setTorchLevel(level: level)
         }
     }
 
-    static func configure(apiKey: String? = nil) {
+    public static func configure(apiKey: String? = nil) {
         // TODO: remove this and just use stripe's main configuration path
     }
 
-    static func supportedOrientationMaskOrDefault() -> UIInterfaceOrientationMask {
+    public static func supportedOrientationMaskOrDefault() -> UIInterfaceOrientationMask {
         guard ScanBaseViewController.isAppearing else {
             // If the ScanBaseViewController isn't appearing then fall back
             // to getting the orientation mask from the infoDictionary, just like
@@ -153,11 +154,11 @@ class ScanBaseViewController: UIViewController, AVCaptureVideoDataOutputSampleBu
         return ScanBaseViewController.isPadAndFormsheet ? .allButUpsideDown : .portrait
     }
 
-    static func isCompatible() -> Bool {
+    public static func isCompatible() -> Bool {
         return self.isCompatible(configuration: ScanConfiguration())
     }
 
-    static func isCompatible(configuration: ScanConfiguration) -> Bool {
+    public static func isCompatible(configuration: ScanConfiguration) -> Bool {
         // check to see if the user has already denined camera permission
         let authorizationStatus = AVCaptureDevice.authorizationStatus(for: .video)
         if authorizationStatus != .authorized && authorizationStatus != .notDetermined
@@ -174,27 +175,27 @@ class ScanBaseViewController: UIViewController, AVCaptureVideoDataOutputSampleBu
         return true
     }
 
-    func cancelScan() {
+    open func cancelScan() {
         guard let ocrMainLoop = ocrMainLoop() else {
             return
         }
         ocrMainLoop.userCancelled()
     }
 
-    func setupMask() {
+    open func setupMask() {
         guard let roi = self.regionOfInterestLabel else { return }
         guard let blurView = self.blurView else { return }
         blurView.maskToRoi(roi: roi)
     }
 
-    func setUpCorners() {
+    open func setUpCorners() {
         guard let roi = self.regionOfInterestLabel else { return }
         guard let corners = self.cornerView else { return }
         corners.setFrameSize(roi: roi)
         corners.drawCorners()
     }
 
-    func permissionDidComplete(granted: Bool, showedPrompt: Bool) {
+    open func permissionDidComplete(granted: Bool, showedPrompt: Bool) {
         self.ocrMainLoop()?.scanStats.permissionGranted = granted
         if !granted {
             self.onCameraPermissionDenied(showedPrompt: showedPrompt)
@@ -204,7 +205,7 @@ class ScanBaseViewController: UIViewController, AVCaptureVideoDataOutputSampleBu
 
     // you must call setupOnViewDidLoad before calling this function and you have to call
     // this function to get the camera going
-    func startCameraPreview() {
+    open func startCameraPreview() {
         self.videoFeed.requestCameraAccess(permissionDelegate: self)
     }
 
@@ -251,7 +252,7 @@ class ScanBaseViewController: UIViewController, AVCaptureVideoDataOutputSampleBu
         #endif
     }
 
-    func setupOnViewDidLoad(
+    open func setupOnViewDidLoad(
         regionOfInterestLabel: UIView,
         blurView: BlurView,
         previewView: PreviewView,
@@ -315,23 +316,23 @@ class ScanBaseViewController: UIViewController, AVCaptureVideoDataOutputSampleBu
         OcrMainLoop()
     }
 
-    override var shouldAutorotate: Bool {
+    open override var shouldAutorotate: Bool {
         return true
     }
 
-    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+    open override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return ScanBaseViewController.isPadAndFormsheet ? .allButUpsideDown : .portrait
     }
 
-    override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
+    open override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
         return ScanBaseViewController.isPadAndFormsheet ? UIWindow.interfaceOrientation : .portrait
     }
 
-    override var preferredStatusBarStyle: UIStatusBarStyle {
+    open override var preferredStatusBarStyle: UIStatusBarStyle {
         return .lightContent
     }
 
-    override func viewWillTransition(
+    open override func viewWillTransition(
         to size: CGSize,
         with coordinator: UIViewControllerTransitionCoordinator
     ) {
@@ -353,7 +354,7 @@ class ScanBaseViewController: UIViewController, AVCaptureVideoDataOutputSampleBu
         }
     }
 
-    override func viewWillAppear(_ animated: Bool) {
+    open override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         ScanBaseViewController.isAppearing = true
         // Set beginning of scan session
@@ -370,7 +371,7 @@ class ScanBaseViewController: UIViewController, AVCaptureVideoDataOutputSampleBu
         self.navigationController?.setNavigationBarHidden(hideNavigationBar, animated: animated)
     }
 
-    override func viewDidLayoutSubviews() {
+    open override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
         self.view.layoutIfNeeded()
@@ -384,12 +385,12 @@ class ScanBaseViewController: UIViewController, AVCaptureVideoDataOutputSampleBu
         self.setupMask()
     }
 
-    override func viewDidAppear(_ animated: Bool) {
+    open override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         self.ocrMainLoop()?.scanStats.orientation = UIWindow.interfaceOrientationToString
     }
 
-    override func viewWillDisappear(_ animated: Bool) {
+    open override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         self.videoFeed.willDisappear()
         self.navigationController?.setNavigationBarHidden(
@@ -398,12 +399,12 @@ class ScanBaseViewController: UIViewController, AVCaptureVideoDataOutputSampleBu
         )
     }
 
-    override func viewDidDisappear(_ animated: Bool) {
+    open override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         ScanBaseViewController.isAppearing = false
     }
 
-    func getScanStats() -> ScanStats {
+    public func getScanStats() -> ScanStats {
         return self.ocrMainLoop()?.scanStats ?? ScanStats()
     }
 
@@ -460,7 +461,7 @@ class ScanBaseViewController: UIViewController, AVCaptureVideoDataOutputSampleBu
         }
     }
 
-    func updateDebugImageView(image: UIImage) {
+    open func updateDebugImageView(image: UIImage) {
         self.debugImageView?.image = image
         if self.debugImageView?.isHidden ?? false {
             self.debugImageView?.isHidden = false
@@ -468,7 +469,7 @@ class ScanBaseViewController: UIViewController, AVCaptureVideoDataOutputSampleBu
     }
 
     // MARK: - OcrMainLoopComplete logic
-    func complete(creditCardOcrResult: CreditCardOcrResult) {
+    open func complete(creditCardOcrResult: CreditCardOcrResult) {
         ocrMainLoop()?.mainLoopDelegate = nil
         // Stop the previewing when we are done
         self.previewView?.videoPreviewLayer.session?.stopRunning()
@@ -492,7 +493,7 @@ class ScanBaseViewController: UIViewController, AVCaptureVideoDataOutputSampleBu
         )
     }
 
-    func prediction(
+    open func prediction(
         prediction: CreditCardOcrPrediction,
         imageData: ScannedCardImageData,
         state: MainLoopState
@@ -556,18 +557,18 @@ class ScanBaseViewController: UIViewController, AVCaptureVideoDataOutputSampleBu
         }
     }
 
-    func showCardDetails(number: String?, expiry: String?, name: String?) {
+    open func showCardDetails(number: String?, expiry: String?, name: String?) {
         guard let number = number else { return }
         showCardNumber(number, expiry: expiry)
     }
 
-    func showCardDetailsWithFlash(number: String?, expiry: String?, name: String?) {
+    open func showCardDetailsWithFlash(number: String?, expiry: String?, name: String?) {
         if !isTorchOn() { toggleTorch() }
         guard let number = number else { return }
         showCardNumber(number, expiry: expiry)
     }
 
-    func shouldUsePrediction(
+    open func shouldUsePrediction(
         errorCorrectedNumber: String?,
         prediction: CreditCardOcrPrediction
     ) -> Bool {

--- a/StripeCardScan/StripeCardScan/Source/CardScan/UI/ScanConfiguration.swift
+++ b/StripeCardScan/StripeCardScan/Source/CardScan/UI/ScanConfiguration.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-enum ScanPerformance: Int {
+public enum ScanPerformance: Int {
     case fast
     case accurate
 }
 
-class ScanConfiguration: NSObject {
-    var runOnOldDevices = false
-    var setPreviouslyDeniedDevicesAsIncompatible = false
+public class ScanConfiguration: NSObject {
+    public var runOnOldDevices = false
+    public var setPreviouslyDeniedDevicesAsIncompatible = false
 }

--- a/StripeCardScan/StripeCardScan/Source/CardScan/UI/ScanEventsProtocol.swift
+++ b/StripeCardScan/StripeCardScan/Source/CardScan/UI/ScanEventsProtocol.swift
@@ -9,7 +9,7 @@
 
 import CoreGraphics
 
-protocol ScanEvents {
+public protocol ScanEvents {
     mutating func onNumberRecognized(
         number: String,
         expiry: Expiry?,

--- a/StripeCardScan/StripeCardScan/Source/CardScan/UI/ScanStats.swift
+++ b/StripeCardScan/StripeCardScan/Source/CardScan/UI/ScanStats.swift
@@ -8,30 +8,30 @@ import CoreGraphics
 import Foundation
 import UIKit
 
-struct ScanStats {
-    var startTime = Date()
-    var scans = 0
-    var flatDigitsRecognized = 0
-    var flatDigitsDetected = 0
-    var embossedDigitsRecognized = 0
-    var embossedDigitsDetected = 0
-    var torchOn = false
-    var orientation = "Portrait"
-    var success: Bool?
-    var endTime: Date?
-    var model: String?
-    var algorithm: String?
-    var bin: String?
-    var lastFlatBoxes: [CGRect]?
-    var lastEmbossedBoxes: [CGRect]?
-    var deviceType: String?
-    var numberRect: CGRect?
-    var expiryBoxes: [CGRect]?
-    var cardsDetected = 0
-    var permissionGranted: Bool?
-    var userCanceled: Bool = false
+public struct ScanStats {
+    public var startTime = Date()
+    public var scans = 0
+    public var flatDigitsRecognized = 0
+    public var flatDigitsDetected = 0
+    public var embossedDigitsRecognized = 0
+    public var embossedDigitsDetected = 0
+    public var torchOn = false
+    public var orientation = "Portrait"
+    public var success: Bool?
+    public var endTime: Date?
+    public var model: String?
+    public var algorithm: String?
+    public var bin: String?
+    public var lastFlatBoxes: [CGRect]?
+    public var lastEmbossedBoxes: [CGRect]?
+    public var deviceType: String?
+    public var numberRect: CGRect?
+    public var expiryBoxes: [CGRect]?
+    public var cardsDetected = 0
+    public var permissionGranted: Bool?
+    public var userCanceled: Bool = false
 
-    init() {
+    public init() {
         var systemInfo = utsname()
         uname(&systemInfo)
         var deviceType = ""
@@ -50,7 +50,7 @@ struct ScanStats {
         self.deviceType = deviceType
     }
 
-    func toDictionaryForAnalytics() -> [String: Any] {
+    public func toDictionaryForAnalytics() -> [String: Any] {
         return [
             "scans": self.scans,
             "cards_detected": self.cardsDetected,
@@ -66,7 +66,7 @@ struct ScanStats {
         ]
     }
 
-    func duration() -> Double {
+    public func duration() -> Double {
         guard let endTime = self.endTime else {
             return 0.0
         }
@@ -74,7 +74,7 @@ struct ScanStats {
         return endTime.timeIntervalSince(self.startTime)
     }
 
-    func image(from base64String: String?) -> UIImage? {
+    public func image(from base64String: String?) -> UIImage? {
         guard let string = base64String else {
             return nil
         }

--- a/StripeCardScan/StripeCardScan/Source/CardScan/UI/SimpleScanViewController.swift
+++ b/StripeCardScan/StripeCardScan/Source/CardScan/UI/SimpleScanViewController.swift
@@ -56,7 +56,7 @@ import UIKit
 // this code and customize it to fit your needs -- we're fine with whatever makes
 // the most sense for your app.
 
-protocol SimpleScanDelegate: AnyObject {
+public protocol SimpleScanDelegate: AnyObject {
     func userDidCancelSimple(_ scanViewController: SimpleScanViewController)
     func userDidScanCardSimple(
         _ scanViewController: SimpleScanViewController,
@@ -64,20 +64,20 @@ protocol SimpleScanDelegate: AnyObject {
     )
 }
 
-class SimpleScanViewController: ScanBaseViewController {
+open class SimpleScanViewController: ScanBaseViewController {
 
     // used by ScanBase
-    var previewView: PreviewView = PreviewView()
-    var blurView: BlurView = BlurView()
-    var roiView: UIView = UIView()
-    var cornerView: CornerView?
+    public var previewView: PreviewView = PreviewView()
+    public var blurView: BlurView = BlurView()
+    public var roiView: UIView = UIView()
+    public var cornerView: CornerView?
 
     // our UI components
-    var descriptionText = UILabel()
-    var privacyLinkText = UITextView()
-    var privacyLinkTextHeightConstraint: NSLayoutConstraint?
+    public var descriptionText = UILabel()
+    public var privacyLinkText = UITextView()
+    public var privacyLinkTextHeightConstraint: NSLayoutConstraint?
 
-    var closeButton: UIButton = {
+    public var closeButton: UIButton = {
         var button = UIButton(type: .system)
         button.setTitleColor(.white, for: .normal)
         button.tintColor = .white
@@ -85,7 +85,7 @@ class SimpleScanViewController: ScanBaseViewController {
         return button
     }()
 
-    var torchButton: UIButton = {
+    public var torchButton: UIButton = {
         var button = UIButton(type: .system)
         button.setTitleColor(.white, for: .normal)
         button.tintColor = .white
@@ -94,29 +94,29 @@ class SimpleScanViewController: ScanBaseViewController {
     }()
 
     private var debugView: UIImageView?
-    var enableCameraPermissionsButton = UIButton(type: .system)
-    var enableCameraPermissionsText = UILabel()
+    public var enableCameraPermissionsButton = UIButton(type: .system)
+    public var enableCameraPermissionsText = UILabel()
 
     // Dynamic card details
-    var numberText = UILabel()
-    var expiryText = UILabel()
-    var nameText = UILabel()
-    var expiryLayoutView = UIView()
+    public var numberText = UILabel()
+    public var expiryText = UILabel()
+    public var nameText = UILabel()
+    public var expiryLayoutView = UIView()
 
     // String
-    static var descriptionString = String.Localized.scan_card_title_capitalization
-    static var enableCameraPermissionString = String.Localized.enable_camera_access
-    static var enableCameraPermissionsDescriptionString = String.Localized.update_phone_settings
-    static var closeButtonString = String.Localized.close
-    static var torchButtonString = String.Localized.torch
-    static var privacyLinkString = String.Localized.scanCardExpectedPrivacyLinkText()
+    public static var descriptionString = String.Localized.scan_card_title_capitalization
+    public static var enableCameraPermissionString = String.Localized.enable_camera_access
+    public static var enableCameraPermissionsDescriptionString = String.Localized.update_phone_settings
+    public static var closeButtonString = String.Localized.close
+    public static var torchButtonString = String.Localized.torch
+    public static var privacyLinkString = String.Localized.scanCardExpectedPrivacyLinkText()
 
-    weak var delegate: SimpleScanDelegate?
-    var scanPerformancePriority: ScanPerformance = .fast
-    var maxErrorCorrectionDuration: Double = 4.0
+    public weak var delegate: SimpleScanDelegate?
+    public var scanPerformancePriority: ScanPerformance = .fast
+    public var maxErrorCorrectionDuration: Double = 4.0
 
     // MARK: Inits
-    override init() {
+    public override init() {
         super.init()
         if UIDevice.current.userInterfaceIdiom == .pad {
             // For the iPad you can use the full screen style but you have to select "requires full screen" in
@@ -128,13 +128,14 @@ class SimpleScanViewController: ScanBaseViewController {
         }
     }
 
-    required init?(
+    @available(*, unavailable)
+    required public init?(
         coder: NSCoder
     ) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func viewDidLoad() {
+    open override func viewDidLoad() {
         super.viewDidLoad()
 
         setupUiComponents()
@@ -159,12 +160,12 @@ class SimpleScanViewController: ScanBaseViewController {
     //  Targets gets added on every setUpUi call.
     //
     //  Figure out a better way of allow custom buttons programmatically instead of whole UI buttons.
-    override func viewDidDisappear(_ animated: Bool) {
+    open override func viewDidDisappear(_ animated: Bool) {
         closeButton.removeTarget(self, action: #selector(cancelButtonPress), for: .touchUpInside)
         torchButton.removeTarget(self, action: #selector(torchButtonPress), for: .touchUpInside)
     }
 
-    func setUpMainLoop(errorCorrectionDuration: Double) {
+    open func setUpMainLoop(errorCorrectionDuration: Double) {
         if scanPerformancePriority == .accurate {
             let mainLoop = self.mainLoop as? OcrMainLoop
             mainLoop?.errorCorrection = ErrorCorrection(
@@ -176,7 +177,7 @@ class SimpleScanViewController: ScanBaseViewController {
     }
 
     // MARK: - Visual and UI event setup for UI components
-    func setupUiComponents() {
+    open func setupUiComponents() {
         view.backgroundColor = .white
         regionOfInterestCornerRadius = 15.0
 
@@ -204,11 +205,11 @@ class SimpleScanViewController: ScanBaseViewController {
         }
     }
 
-    func setupPreviewViewUi() {
+    open func setupPreviewViewUi() {
         // no ui setup
     }
 
-    func setupBlurViewUi() {
+    open func setupBlurViewUi() {
         blurView.backgroundColor = #colorLiteral(
             red: 0.2411109507,
             green: 0.271378696,
@@ -217,26 +218,26 @@ class SimpleScanViewController: ScanBaseViewController {
         )
     }
 
-    func setupRoiViewUi() {
+    open func setupRoiViewUi() {
         roiView.layer.borderColor = UIColor.white.cgColor
     }
 
-    func setupCloseButtonUi() {
+    open func setupCloseButtonUi() {
         closeButton.addTarget(self, action: #selector(cancelButtonPress), for: .touchUpInside)
     }
 
-    func setupTorchButtonUi() {
+    open func setupTorchButtonUi() {
         torchButton.addTarget(self, action: #selector(torchButtonPress), for: .touchUpInside)
     }
 
-    func setupDescriptionTextUi() {
+    open func setupDescriptionTextUi() {
         descriptionText.text = SimpleScanViewController.descriptionString
         descriptionText.textColor = .white
         descriptionText.textAlignment = .center
         descriptionText.font = descriptionText.font.withSize(30)
     }
 
-    func setupCardDetailsUi() {
+    open func setupCardDetailsUi() {
         numberText.isHidden = true
         numberText.textColor = .white
         numberText.textAlignment = .center
@@ -254,7 +255,7 @@ class SimpleScanViewController: ScanBaseViewController {
         nameText.font = expiryText.font.withSize(20)
     }
 
-    func setupDenyUi() {
+    open func setupDenyUi() {
         let text = SimpleScanViewController.enableCameraPermissionString
         let attributedString = NSMutableAttributedString(string: text)
         attributedString.addAttribute(
@@ -298,7 +299,7 @@ class SimpleScanViewController: ScanBaseViewController {
         enableCameraPermissionsText.isHidden = true
     }
 
-    func setupPrivacyLinkTextUi() {
+    open func setupPrivacyLinkTextUi() {
         if let attributedString = SimpleScanViewController.privacyLinkString {
             privacyLinkText.attributedText = attributedString
         }
@@ -317,14 +318,14 @@ class SimpleScanViewController: ScanBaseViewController {
         privacyLinkText.clipsToBounds = true
     }
 
-    func setupDebugViewUi() {
+    open func setupDebugViewUi() {
         debugView = UIImageView()
         guard let debugView = debugView else { return }
         self.view.addSubview(debugView)
     }
 
     // MARK: - Autolayout constraints
-    func setupConstraints() {
+    open func setupConstraints() {
         let children: [UIView] = [
             previewView, blurView, roiView, descriptionText, closeButton, torchButton, numberText,
             expiryText, nameText, expiryLayoutView, enableCameraPermissionsButton,
@@ -349,16 +350,16 @@ class SimpleScanViewController: ScanBaseViewController {
         }
     }
 
-    func setupPreviewViewConstraints() {
+    open func setupPreviewViewConstraints() {
         // make it full screen
         previewView.setAnchorsEqual(to: self.view)
     }
 
-    func setupBlurViewConstraints() {
+    open func setupBlurViewConstraints() {
         blurView.setAnchorsEqual(to: self.previewView)
     }
 
-    func setupRoiViewConstraints() {
+    open func setupRoiViewConstraints() {
         roiView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16).isActive = true
         roiView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16).isActive =
             true
@@ -367,19 +368,19 @@ class SimpleScanViewController: ScanBaseViewController {
         roiView.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
     }
 
-    func setupCloseButtonConstraints() {
+    open func setupCloseButtonConstraints() {
         let margins = view.layoutMarginsGuide
         closeButton.topAnchor.constraint(equalTo: margins.topAnchor, constant: 16.0).isActive = true
         closeButton.leadingAnchor.constraint(equalTo: margins.leadingAnchor).isActive = true
     }
 
-    func setupTorchButtonConstraints() {
+    open func setupTorchButtonConstraints() {
         let margins = view.layoutMarginsGuide
         torchButton.topAnchor.constraint(equalTo: margins.topAnchor, constant: 16.0).isActive = true
         torchButton.trailingAnchor.constraint(equalTo: margins.trailingAnchor).isActive = true
     }
 
-    func setupDescriptionTextConstraints() {
+    open func setupDescriptionTextConstraints() {
         descriptionText.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 32).isActive =
             true
         descriptionText.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -32)
@@ -388,7 +389,7 @@ class SimpleScanViewController: ScanBaseViewController {
             true
     }
 
-    func setupCardDetailsConstraints() {
+    open func setupCardDetailsConstraints() {
         numberText.leadingAnchor.constraint(equalTo: roiView.leadingAnchor, constant: 32).isActive =
             true
         numberText.trailingAnchor.constraint(equalTo: roiView.trailingAnchor, constant: -32)
@@ -411,7 +412,7 @@ class SimpleScanViewController: ScanBaseViewController {
         expiryText.centerYAnchor.constraint(equalTo: expiryLayoutView.centerYAnchor).isActive = true
     }
 
-    func setupDenyConstraints() {
+    open func setupDenyConstraints() {
         NSLayoutConstraint.activate([
             enableCameraPermissionsButton.topAnchor.constraint(
                 equalTo: privacyLinkText.bottomAnchor,
@@ -428,7 +429,7 @@ class SimpleScanViewController: ScanBaseViewController {
         ])
     }
 
-    func setupPrivacyLinkTextConstraints() {
+    open func setupPrivacyLinkTextConstraints() {
         NSLayoutConstraint.activate([
             privacyLinkText.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 32),
             privacyLinkText.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -32),
@@ -440,7 +441,7 @@ class SimpleScanViewController: ScanBaseViewController {
         )
     }
 
-    func setupDebugViewConstraints() {
+    open func setupDebugViewConstraints() {
         guard let debugView = debugView else { return }
         debugView.translatesAutoresizingMaskIntoConstraints = false
 
@@ -467,7 +468,7 @@ class SimpleScanViewController: ScanBaseViewController {
         delegate?.userDidScanCardSimple(self, creditCard: card)
     }
 
-    func showScannedCardDetails(prediction: CreditCardOcrPrediction) {
+    open func showScannedCardDetails(prediction: CreditCardOcrPrediction) {
         guard let number = prediction.number else {
             return
         }
@@ -492,7 +493,7 @@ class SimpleScanViewController: ScanBaseViewController {
         }
     }
 
-    override func prediction(
+    open override func prediction(
         prediction: CreditCardOcrPrediction,
         imageData: ScannedCardImageData,
         state: MainLoopState
@@ -502,7 +503,7 @@ class SimpleScanViewController: ScanBaseViewController {
         showScannedCardDetails(prediction: prediction)
     }
 
-    override func onCameraPermissionDenied(showedPrompt: Bool) {
+    open override func onCameraPermissionDenied(showedPrompt: Bool) {
         descriptionText.isHidden = true
         torchButton.isHidden = true
 
@@ -512,17 +513,17 @@ class SimpleScanViewController: ScanBaseViewController {
     }
 
     // MARK: - UI event handlers
-    @objc func cancelButtonPress() {
+    @objc open func cancelButtonPress() {
         delegate?.userDidCancelSimple(self)
         self.cancelScan()
     }
 
-    @objc func torchButtonPress() {
+    @objc open func torchButtonPress() {
         toggleTorch()
     }
 
     /// Warning: if the user navigates to settings and updates the setting, it'll suspend your app.
-    @objc func enableCameraPermissionsPress() {
+    @objc open func enableCameraPermissionsPress() {
         guard let settingsUrl = URL(string: UIApplication.openSettingsURLString),
             UIApplication.shared.canOpenURL(settingsUrl)
         else {
@@ -534,7 +535,7 @@ class SimpleScanViewController: ScanBaseViewController {
 }
 
 extension UIView {
-    func setAnchorsEqual(to otherView: UIView) {
+    public func setAnchorsEqual(to otherView: UIView) {
         self.topAnchor.constraint(equalTo: otherView.topAnchor).isActive = true
         self.leadingAnchor.constraint(equalTo: otherView.leadingAnchor).isActive = true
         self.trailingAnchor.constraint(equalTo: otherView.trailingAnchor).isActive = true

--- a/StripeCardScan/StripeCardScan/Source/CardScan/UI/VideoFeed.swift
+++ b/StripeCardScan/StripeCardScan/Source/CardScan/UI/VideoFeed.swift
@@ -1,7 +1,7 @@
 import AVKit
 import VideoToolbox
 
-protocol AfterPermissions {
+public protocol AfterPermissions {
     func permissionDidComplete(granted: Bool, showedPrompt: Bool)
 }
 

--- a/StripeCardScan/StripeCardScan/Source/CardVerify/Card Image Verification/ScannedCardImageData.swift
+++ b/StripeCardScan/StripeCardScan/Source/CardVerify/Card Image Verification/ScannedCardImageData.swift
@@ -9,13 +9,13 @@ import Foundation
 import UIKit
 
 /// Data structure representing an image frame captured during the scanning flow.
-struct ScannedCardImageData {
+public struct ScannedCardImageData {
     /// The image of the scanned card after it has been converted from AVCaptureSession to the video preview layer coordinate system
-    let previewLayerImage: CGImage
+    public let previewLayerImage: CGImage
     /// The viewfinder bounds after it has been converted from the AVCaptureSession to the video preview layer coordinate system
-    let previewLayerViewfinderRect: CGRect
+    public let previewLayerViewfinderRect: CGRect
 
-    init(
+    public init(
         previewLayerImage: CGImage,
         previewLayerViewfinderRect: CGRect
     ) {
@@ -23,7 +23,7 @@ struct ScannedCardImageData {
         self.previewLayerViewfinderRect = previewLayerViewfinderRect
     }
 
-    init?(
+    public init?(
         captureDeviceImage: CGImage,
         viewfinderRect: CGRect,
         previewViewRect: CGRect
@@ -57,9 +57,9 @@ struct ScannedCardImageData {
 /// TODO(jaimepark): Update conversion methods to calculate based on only AVCaputureSessionPreviewLayer.
 /// Currently, .FullScreenAndRoi returns both the converted image and view finder rect. Once the conversion logic
 /// is updated, the params will be updated and these functions will be DRY-ed up.
-extension ScannedCardImageData {
+public extension ScannedCardImageData {
     /// Using legacy SDK logic, returns the AVCaptureDevice-to-preview view layer converted image
-    static func convertToPreviewLayerImage(
+    public static func convertToPreviewLayerImage(
         captureDeviceImage: CGImage,
         viewfinderRect: CGRect,
         previewViewRect: CGRect
@@ -77,7 +77,7 @@ extension ScannedCardImageData {
     }
 
     /// Using legacy SDK logic, returns the AVCaptureDevice-to-preview view layer converted view finder rect
-    static func convertToPreviewLayerRect(
+    public static func convertToPreviewLayerRect(
         captureDeviceImage: CGImage,
         viewfinderRect: CGRect,
         previewViewRect: CGRect

--- a/StripeCardScan/StripeCardScan/Source/CardVerify/CardScanMisc.swift
+++ b/StripeCardScan/StripeCardScan/Source/CardVerify/CardScanMisc.swift
@@ -1,4 +1,5 @@
 import AVKit
+import UIKit
 
 protocol CaptureOutputDelegate {
     func capture(
@@ -8,22 +9,22 @@ protocol CaptureOutputDelegate {
     )
 }
 
-class CreditCard: NSObject {
-    var number: String
-    var expiryMonth: String?
-    var expiryYear: String?
-    var name: String?
-    var image: UIImage?
-    var cvv: String?
-    var postalCode: String?
+public class CreditCard: NSObject {
+    public var number: String
+    public var expiryMonth: String?
+    public var expiryYear: String?
+    public var name: String?
+    public var image: UIImage?
+    public var cvv: String?
+    public var postalCode: String?
 
-    init(
+    public init(
         number: String
     ) {
         self.number = number
     }
 
-    func expiryForDisplay() -> String? {
+    public func expiryForDisplay() -> String? {
         guard var month = self.expiryMonth, var year = self.expiryYear else {
             return nil
         }


### PR DESCRIPTION
## Summary
- make `ScanBaseViewController`, `SimpleScanViewController`, and related UI helpers public/open for customization
- expose configuration, delegate protocols, and supporting data models used during card scanning
- surface OCR prediction/result types and the `CreditCard` model so external UIs can react to scan updates

## Testing
- `xcodebuild -workspace Stripe.xcworkspace -scheme StripeCardScan -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' build` *(fails: command not found: xcodebuild)*


------
https://chatgpt.com/codex/tasks/task_e_68d3d5b05d4c8321814f1903132415c6